### PR TITLE
Correct calendar session count display

### DIFF
--- a/js/uiManager.js
+++ b/js/uiManager.js
@@ -814,7 +814,7 @@ class UIManager {
             
             html += `
                 <div class="${classes}" data-date="${dateStr}">
-                    ${day}
+                    <span class="calendar-day-number">${day}</span>
                     ${hasSession ? `<span class="session-count">${hasSession}</span>` : ''}
                 </div>
             `;

--- a/styles/components.css
+++ b/styles/components.css
@@ -397,6 +397,8 @@
     cursor: pointer;
     transition: all var(--transition-fast);
     position: relative;
+    flex-direction: column;
+    padding: 4px;
 }
 
 .calendar-day:hover {
@@ -409,14 +411,7 @@
 }
 
 .calendar-day.has-session::after {
-    content: '';
-    position: absolute;
-    bottom: 2px;
-    right: 2px;
-    width: 6px;
-    height: 6px;
-    background: var(--primary-gold);
-    border-radius: 50%;
+    display: none;
 }
 
 .calendar-day.today {
@@ -429,22 +424,20 @@
     font-size: 1.1em;
     font-weight: 600;
     display: block;
+    margin-bottom: 2px;
 }
 
 .session-count {
     display: inline-block;
     background: var(--primary-gold, gold);
     color: var(--text-primary, #222);
-    font-size: 0.7em;
+    font-size: 0.6em;
     font-weight: 700;
     border-radius: 50%;
-    min-width: 1.5em;
-    min-height: 1.5em;
-    line-height: 1.5em;
+    min-width: 1.2em;
+    min-height: 1.2em;
+    line-height: 1.2em;
     text-align: center;
-    position: absolute;
-    top: 4px;
-    right: 4px;
     box-shadow: 0 1px 3px rgba(0,0,0,0.08);
     z-index: 2;
 }

--- a/styles/components.css
+++ b/styles/components.css
@@ -425,6 +425,30 @@
     font-weight: 700;
 }
 
+.calendar-day-number {
+    font-size: 1.1em;
+    font-weight: 600;
+    display: block;
+}
+
+.session-count {
+    display: inline-block;
+    background: var(--primary-gold, gold);
+    color: var(--text-primary, #222);
+    font-size: 0.7em;
+    font-weight: 700;
+    border-radius: 50%;
+    min-width: 1.5em;
+    min-height: 1.5em;
+    line-height: 1.5em;
+    text-align: center;
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    z-index: 2;
+}
+
 /* Charts */
 .chart-wrapper {
     background: var(--bg-secondary);


### PR DESCRIPTION
Fix calendar day display to show session count as a separate badge, preventing it from merging with the day number.

The previous attempt to separate the day number and session count in the HTML was insufficient due to conflicting CSS rules (flexbox layout and an existing `::after` pseudo-element). This PR adjusts the `.calendar-day` flex direction, disables the old session indicator, and introduces specific styling for the day number and session count to ensure they are displayed distinctly.