### PR TITLE
Fix session duration overlay on icons

### DIFF
--- a/styles/components.css
+++ b/styles/components.css
@@ -205,7 +205,7 @@
 
 .session-actions {
     position: absolute;
-    top: var(--space-md);
+    bottom: var(--space-md);
     right: var(--space-md);
     display: flex;
     gap: var(--space-xs);


### PR DESCRIPTION
Adjust position of session action icons to prevent overlap with session duration.

---

[Open in Web](https://www.cursor.com/agents?id=bc-42efd38d-cef6-4cc1-8411-592cd9a4e25f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-42efd38d-cef6-4cc1-8411-592cd9a4e25f)