### PR TITLE
Correct belt hour calculation on statistics page

### DIFF
--- a/js/statisticsPredictor.js
+++ b/js/statisticsPredictor.js
@@ -394,7 +394,6 @@ class StatisticsPredictor {
         const predictedMonthlyHours = monthlyPrediction.hours;
         
         const predictions = [];
-        let accumulatedHours = currentHours;
         let monthsFromNow = 0;
         
         // Predict next 3 belt progressions
@@ -407,7 +406,8 @@ class StatisticsPredictor {
             const hourRequirement = requirements.find(req => req.type === 'totalHours');
             if (!hourRequirement) continue;
             
-            const hoursNeeded = hourRequirement.value - accumulatedHours;
+            // Calculate hours needed from current position (cumulative)
+            const hoursNeeded = hourRequirement.value - currentHours;
             
             if (hoursNeeded <= 0) {
                 predictions.push({
@@ -434,9 +434,6 @@ class StatisticsPredictor {
                     confidence: Math.max(20, 90 - (monthsNeeded * 5)) // Decreasing confidence over time
                 });
             }
-            
-            // Always update accumulated hours to current belt requirement for next iteration
-            accumulatedHours = hourRequirement.value;
         }
         
         return {

--- a/js/statisticsPredictor.js
+++ b/js/statisticsPredictor.js
@@ -433,9 +433,10 @@ class StatisticsPredictor {
                     estimatedDate: this.getEstimatedDate(monthsNeeded),
                     confidence: Math.max(20, 90 - (monthsNeeded * 5)) // Decreasing confidence over time
                 });
-                
-                accumulatedHours = hourRequirement.value;
             }
+            
+            // Always update accumulated hours to current belt requirement for next iteration
+            accumulatedHours = hourRequirement.value;
         }
         
         return {


### PR DESCRIPTION
Update belt progression calculation to show cumulative hours needed from current position.

Previously, the "hours needed" for subsequent belts (e.g., Brown) was calculated incrementally from the *previous* belt's requirement. This PR changes it to calculate cumulatively from the user's *current* total hours, aligning with the user's expectation that "Brown is 100 (to Blue) plus 130 (from Blue to Brown) = 230 total from current".

---

[Open in Web](https://www.cursor.com/agents?id=bc-bfec1c37-8c47-4242-bb56-1a2a5d5b1369) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-bfec1c37-8c47-4242-bb56-1a2a5d5b1369)